### PR TITLE
Fix release build

### DIFF
--- a/.github/workflows/release_droid_prepare_original_checksum.yml
+++ b/.github/workflows/release_droid_prepare_original_checksum.yml
@@ -25,7 +25,7 @@ jobs:
         env:
           ABS_CS: ${{ secrets.ABS_CS }}
       - name: Run tests and build with Maven
-        run: mvn --batch-mode clean verify --file pom.xml
+        run: mvn --batch-mode clean verify -Dcom.exasol.dockerdb.image=7.1.24
       - name: Prepare checksum
         run: find target -maxdepth 1 -name *.jar -exec sha256sum "{}" + > original_checksum
       - name: Upload checksum to the artifactory


### PR DESCRIPTION
Testcontainers uses Exasol version 8 by default now. Until this projects works with Exasol 8 we need to override the version.